### PR TITLE
Bump Spire.Doc from 9.9.6 to 9.10.0

### DIFF
--- a/WMSPharmacy/packages.config
+++ b/WMSPharmacy/packages.config
@@ -11,7 +11,7 @@
   <package id="NLog.Config" version="4.7.11" targetFramework="net472" />
   <package id="NLog.Schema" version="4.7.11" targetFramework="net472" />
   <package id="Spire.DataExport" version="3.5.10" targetFramework="net472" />
-  <package id="Spire.Doc" version="9.9.6" targetFramework="net472" />
+  <package id="Spire.Doc" version="9.10.0" targetFramework="net472" />
   <package id="Spire.PDF" version="7.9.6" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="5.0.0" targetFramework="net472" />


### PR DESCRIPTION
Bumps Spire.Doc from 9.9.6 to 9.10.0.

---
updated-dependencies:
- dependency-name: Spire.Doc
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>